### PR TITLE
fix(docker): Update portainer-docker-compose.yml

### DIFF
--- a/portainer-docker-compose.yml
+++ b/portainer-docker-compose.yml
@@ -1,8 +1,7 @@
-version: '3.7'
- 
+#version: '3.7'
 services:
     portainer:
-        image: portainer/portainer-ce
+        image: portainer/portainer-ce:2.20.1
         container_name: portainer
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Added "ce" version to avoid errors when trying to access cli interface from Portainer. https://github.com/portainer/portainer/issues/11436#issuecomment-2117838755

Also, commented out "version" in top of file as it is throwing deprecation warning https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional